### PR TITLE
chore: auto-install deps on codespace create

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,6 +5,7 @@
   "features": {
     "ghcr.io/devcontainers/features/node:1": {}
   },
+  "postCreateCommand": "pnpm install",
   "customizations": {
     "vscode": {
       "extensions": [


### PR DESCRIPTION
## Summary
- Add `postCreateCommand: pnpm install` to `.devcontainer/devcontainer.json` so dependencies are installed automatically when the codespace is created.
- Fixes the issue where `npx cucumber-js` (used by the cucumber-quick IDE extension) would fall back to fetching a placeholder package from the registry because `node_modules/.bin/cucumber-js` did not exist.

## Test plan
- [ ] Rebuild the codespace and confirm `pnpm install` runs during creation
- [ ] Confirm `node_modules/.bin/cucumber-js` exists after creation
- [ ] Run a feature via the cucumber-quick IDE action and confirm it executes locally without fetching from the npm registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)